### PR TITLE
Gen2 ouster support

### DIFF
--- a/urdf/ouster.urdf.xacro
+++ b/urdf/ouster.urdf.xacro
@@ -54,8 +54,8 @@
     <joint name="ouster_sensor_to_lidar" type="fixed">
       <!-- origin queried from device -->
       <origin xyz="0 0 0.03618" rpy="0 0 ${pi}" />
-      <parent link="os1_sensor" />
-      <child link="os1_lidar" />
+      <parent link="os_sensor" />
+      <child link="os_lidar" />
     </joint>
     <link name="os_lidar" />
     <joint name="ouster_sensor_to_imu" type="fixed">

--- a/urdf/ouster.urdf.xacro
+++ b/urdf/ouster.urdf.xacro
@@ -15,17 +15,17 @@
 -->
 
 
-<!-- Ouster OS1 Lidar Sensor -->
-<robot name="os1" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<!-- Ouster OS Lidar Sensor -->
+<robot name="os" xmlns:xacro="http://www.ros.org/wiki/xacro">
 <xacro:arg name="simulation" default="false" />
 
-<xacro:macro name="os1_device" params="parent *origin name:=os1_lidar simulation:=false">
+<xacro:macro name="os_device" params="parent *origin name:=os1_lidar simulation:=false">
   <joint name="${parent}_to_ouster" type="fixed">
     <xacro:insert_block name="origin"/>
     <parent link="${parent}" />
-    <child link="os1_sensor" />
+    <child link="os_sensor" />
   </joint>
-  <link name="os1_sensor">
+  <link name="os_sensor">
     <visual>
       <origin xyz="0 0 0" rpy="${pi/2} 0 ${pi/2}" />
       <geometry>
@@ -57,14 +57,14 @@
       <parent link="os1_sensor" />
       <child link="os1_lidar" />
     </joint>
-    <link name="os1_lidar" />
+    <link name="os_lidar" />
     <joint name="ouster_sensor_to_imu" type="fixed">
       <!-- origin queried from device -->
       <origin xyz="0.006253 -0.011775 0.007645" rpy="0 0 0" />
-      <parent link="os1_sensor" />
-      <child link="os1_imu" />
+      <parent link="os_sensor" />
+      <child link="os_imu" />
     </joint>
-    <link name="os1_imu" />
+    <link name="os_imu" />
   </xacro:if> 
 </xacro:macro>
 

--- a/urdf/rooster.urdf.xacro
+++ b/urdf/rooster.urdf.xacro
@@ -46,10 +46,10 @@
       <child link="base_mount" />
       <xacro:insert_block name="origin" />
     </joint>
-    <!-- add OS1 Ouster Lidar sensor -->
-    <xacro:os1_device name="os1_sensor" parent="base_mount" simulation="${simulation}">
+    <!-- add OS Ouster Lidar sensor -->
+    <xacro:os_device name="os1_sensor" parent="base_mount" simulation="${simulation}">
       <origin xyz="0 0 77.258e-3" rpy="0 0 ${-pi/4}" />
-    </xacro:os1_device>
+    </xacro:os_device>
     <!-- add RealSense D435i (the mesh is actually the non-IMU version -->
     <xacro:sensor_d435i name="camera" parent="realsense_parent" use_nominal_extrinsics="${simulation}">
       <origin xyz="0 0 0" rpy="0 0 0" />


### PR DESCRIPTION
This PR updates the names according to the new ouster conventions (e.g. `os1_lidar` -> `os_lidar`)