### PR TITLE
Fix problems with urdf when including in another robot model

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ handheld device designed to perform visual-inertial and LIDAR navigation algorit
 ## Rooster Macro Parameters
  - `simulation`: if true, it generates all the links for optical frames that are normally advertized by the sensor drivers
  - `parent`: name of the root link of the device (default is: `base`)
- - `origin`: xacro block that connects `parent` to `base_mount`
+ - `origin`: xacro block that connects `parent` to `rooster_mount`
  - `ground_camera`: if true, it adds the ground facing camera and the relative shim to support it
 
 ## Standalone Rooster Xacro Arguments:
@@ -25,7 +25,7 @@ handheld device designed to perform visual-inertial and LIDAR navigation algorit
 
 ## Standalone  Rooster URDF Frames:
  - `base` : coincident with the left camera optical frame with x-forward, y-left, z-up convention. The ground truth is expressed in this frame.
- - `base_mount`: located at the bottom of the Rooster, with z-axis coincident with the ouster sensor frame.
+ - `rooster_mount`: located at the bottom of the Rooster, with z-axis coincident with the ouster sensor frame.
  - `realsense_parent` : the frame located at the bottom screw hole plate of the RealSense D435i is located here
  - `os1_sensor` : conventional base link for the Ouster. 
                   It is at the bottom of the sensor and the top of the Rooster, 45 deg clockwise rotate on z-axis due to cabling.

--- a/urdf/rooster.urdf.xacro
+++ b/urdf/rooster.urdf.xacro
@@ -19,7 +19,7 @@
   <xacro:include filename="$(find ouster_description)/urdf/ouster.urdf.xacro" />
   <xacro:macro name="rooster_device" params="parent:=base *origin simulation:=false ground_camera:=false">
     <!-- TODO make the xacro parametric against rooster version -->
-    <link name="rooster_base_mount">
+    <link name="rooster_mount">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
@@ -42,11 +42,11 @@
     </link>
     <joint name="${parent}_to_mount" type="fixed">
       <parent link="${parent}" />
-      <child link="rooster_base_mount" />
+      <child link="rooster_mount" />
       <xacro:insert_block name="origin" />
     </joint>
     <!-- add OS Ouster Lidar sensor -->
-    <xacro:os_device name="os1_sensor" parent="rooster_base_mount" simulation="${simulation}">
+    <xacro:os_device name="os1_sensor" parent="rooster_mount" simulation="${simulation}">
       <origin xyz="0 0 77.258e-3" rpy="0 0 ${-pi/4}" />
     </xacro:os_device>
     <!-- add RealSense D435i (the mesh is actually the non-IMU version -->
@@ -56,7 +56,7 @@
     <link name="realsense_parent" />
     <joint name="base_to_realsense" type="fixed">
       <origin xyz="73.65e-3 7.5e-3 50.75e-3" rpy="0 0 0" />
-      <parent link="rooster_base_mount" />
+      <parent link="rooster_mount" />
       <child link="realsense_parent" />
     </joint>
     <!-- the geometric center of the bottom screws is not
@@ -64,9 +64,9 @@
          (i.e., geometry center of device, 
          coincident with ouster center) -->
     <link name="bottom_screws_center" />
-    <joint name="rooster_base_mount_to_bottom_screws_center" type="fixed">
+    <joint name="rooster_mount_to_bottom_screws_center" type="fixed">
       <origin xyz="0 0.475e-3 0" rpy="0 0 0" />
-      <parent link="rooster_base_mount" />
+      <parent link="rooster_mount" />
       <child link="bottom_screws_center" />
     </joint>
     <xacro:if value="${ground_camera}">
@@ -87,7 +87,7 @@
       </link>
       <joint name="ground_camera_shim_joint" type="fixed">
         <origin xyz="59.5e-3 0 38.7e-3" rpy="0 0 0" />
-        <parent link="rooster_base_mount" />
+        <parent link="rooster_mount" />
         <child link="ground_camera_shim" />
       </joint>
       <xacro:sensor_d435i name="ground_camera" parent="ground_camera_shim" use_nominal_extrinsics="${simulation}">

--- a/urdf/rooster.urdf.xacro
+++ b/urdf/rooster.urdf.xacro
@@ -19,7 +19,7 @@
   <xacro:include filename="$(find ouster_description)/urdf/ouster.urdf.xacro" />
   <xacro:macro name="rooster_device" params="parent:=base *origin simulation:=false ground_camera:=false">
     <!-- TODO make the xacro parametric against rooster version -->
-    <link name="base_mount">
+    <link name="rooster_base_mount">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
@@ -42,11 +42,11 @@
     </link>
     <joint name="${parent}_to_mount" type="fixed">
       <parent link="${parent}" />
-      <child link="base_mount" />
+      <child link="rooster_base_mount" />
       <xacro:insert_block name="origin" />
     </joint>
     <!-- add OS Ouster Lidar sensor -->
-    <xacro:os_device name="os1_sensor" parent="base_mount" simulation="${simulation}">
+    <xacro:os_device name="os1_sensor" parent="rooster_base_mount" simulation="${simulation}">
       <origin xyz="0 0 77.258e-3" rpy="0 0 ${-pi/4}" />
     </xacro:os_device>
     <!-- add RealSense D435i (the mesh is actually the non-IMU version -->
@@ -56,7 +56,7 @@
     <link name="realsense_parent" />
     <joint name="base_to_realsense" type="fixed">
       <origin xyz="73.65e-3 7.5e-3 50.75e-3" rpy="0 0 0" />
-      <parent link="base_mount" />
+      <parent link="rooster_base_mount" />
       <child link="realsense_parent" />
     </joint>
     <!-- the geometric center of the bottom screws is not
@@ -64,9 +64,9 @@
          (i.e., geometry center of device, 
          coincident with ouster center) -->
     <link name="bottom_screws_center" />
-    <joint name="base_mount_to_bottom_screws_center" type="fixed">
+    <joint name="rooster_base_mount_to_bottom_screws_center" type="fixed">
       <origin xyz="0 0.475e-3 0" rpy="0 0 0" />
-      <parent link="base_mount" />
+      <parent link="rooster_base_mount" />
       <child link="bottom_screws_center" />
     </joint>
     <xacro:if value="${ground_camera}">
@@ -87,7 +87,7 @@
       </link>
       <joint name="ground_camera_shim_joint" type="fixed">
         <origin xyz="59.5e-3 0 38.7e-3" rpy="0 0 0" />
-        <parent link="base_mount" />
+        <parent link="rooster_base_mount" />
         <child link="ground_camera_shim" />
       </joint>
       <xacro:sensor_d435i name="ground_camera" parent="ground_camera_shim" use_nominal_extrinsics="${simulation}">

--- a/urdf/rooster.urdf.xacro
+++ b/urdf/rooster.urdf.xacro
@@ -19,7 +19,6 @@
   <xacro:include filename="$(find ouster_description)/urdf/ouster.urdf.xacro" />
   <xacro:macro name="rooster_device" params="parent:=base *origin simulation:=false ground_camera:=false">
     <!-- TODO make the xacro parametric against rooster version -->
-    <link name="${parent}" />
     <link name="base_mount">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -70,7 +69,7 @@
       <parent link="base_mount" />
       <child link="bottom_screws_center" />
     </joint>
-    <xacro:if value="$(arg ground_camera)">
+    <xacro:if value="${ground_camera}">
       <link name="ground_camera_shim">
         <visual>
           <geometry>

--- a/urdf/rooster_standalone.urdf.xacro
+++ b/urdf/rooster_standalone.urdf.xacro
@@ -18,6 +18,7 @@
   <xacro:include filename="$(find rooster_description)/urdf/rooster.urdf.xacro" />
   <xacro:arg name="simulation" default="false" />
   <xacro:arg name="ground_camera" default="false" />
+  <link name="base"/>
   <xacro:rooster_device parent="base" simulation="$(arg simulation)" ground_camera="$(arg ground_camera)">
     <!-- this transform makes the robot base coincident with the front camera link -->
     <origin xyz="-0.08425 -0.025 -0.06325" rpy="0 0 0" />


### PR DESCRIPTION
When setting up with spot with this file

```
<?xml version="1.0"?>
<robot name="spot_rooster" xmlns:xacro="http://www.ros.org/wiki/xacro">
  <xacro:include filename="$(find rooster_description)/urdf/rooster.urdf.xacro"/>

  <xacro:rooster_device parent="front_rail">
    <origin xyz="0.073 0 0.025" rpy="0 0 0" />
  </xacro:rooster_device>
</robot>
```

Starting up the spot launch would result in the following error

```
xacro: in-order processing became default in ROS Melodic. You can drop the option.
Undefined substitution argument ground_camera
when instantiating macro: rooster_device (/home/michal/robots/drs/catkin_ws/src/rooster_description/urdf/rooster.urdf.xacro)
in file: /home/michal/robots/drs/catkin_ws/src/spot_ros/spot_description/urdf/spot.urdf.xacro
RLException: while processing /home/michal/robots/drs/catkin_ws/src/spot_ros/spot_description/launch/description.launch:
Invalid <param> tag: Cannot load command parameter [robot_description]: command [['/opt/ros/noetic/lib/xacro/xacro', '/home/michal/robots/drs/catkin_ws/src/spot_ros/spot_description/urdf/spot.urdf.xacro', '--inorder', 'static_camera_frames:=true']] returned with code [2]. 
Param xml is <param name="robot_description" command="$(find xacro)/xacro $(find spot_description)/urdf/spot.urdf.xacro --inorder static_camera_frames:=$(arg static_camera_frames) "/>
The traceback for the exception was written to the log file
```

This was caused by the roslaunch arg syntax being used rather than the xacro syntax.

Once that was fixed there was another complaint

```
[ERROR] [1619708753.961846424]: link 'front_rail' is not unique.
process[rviz-4]: started with pid [40161]
[robot_state_publisher-2] process has died [pid 40154, exit code 1, cmd /opt/ros/noetic/lib/robot_state_publisher/robot_state_publisher __name:=robot_state_publisher __log:=/home/michal/.ros/log/64288542-a8fc-11eb-84f3-9f79388df3a5/robot_state_publisher-2.log].
log file: /home/michal/.ros/log/64288542-a8fc-11eb-84f3-9f79388df3a5/robot_state_publisher-2*.log
[ERROR] [1619708754.551208814]: link 'front_rail' is not unique.
```

This was caused by the parent frame being used to create a new link. This error was hidden because when using the view_urdf this was actually necessary because rooster_standalone.urdf.xacro did not include the base link. That is also fixed in this PR.