### PR TITLE
Add parameter to allow rotation of ouster to be set

### DIFF
--- a/launch/load.launch
+++ b/launch/load.launch
@@ -5,9 +5,11 @@
   <arg name="model"                 default="$(find rooster_description)/urdf/rooster_standalone.urdf.xacro" />
   <arg name="ground_camera"         default="false" />
   <arg name="robot_state_publisher" default="false" />
+  <!-- Sometimes the ouster may have a different rotation to the default, -pi/4 -->
+  <arg name="ouster_rotation"       default="-0.7853981633974483"/>
 
   <!-- Load robot description -->
-  <param name="robot_description" command="xacro $(arg model) simulation:=$(arg simulation) ground_camera:=$(arg ground_camera)" />
+  <param name="robot_description" command="xacro $(arg model) simulation:=$(arg simulation) ground_camera:=$(arg ground_camera) ouster_rotation:=$(arg ouster_rotation)" />
 
   <!-- Launch robot_state_publisher if required -->
   <node if="$(arg robot_state_publisher)" name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />

--- a/urdf/rooster.urdf.xacro
+++ b/urdf/rooster.urdf.xacro
@@ -23,7 +23,8 @@
                                              ground_camera:=false
                                              ouster_vertical_angle:=45
                                              ouster_beams:=64
-                                             ouster_hz:=10">
+                                             ouster_hz:=10
+                                             ouster_rotation=${-pi/4}">
     <!-- TODO make the xacro parametric against rooster version -->
     <link name="rooster_mount">
       <visual>
@@ -53,7 +54,7 @@
     </joint>
     <!-- add OS Ouster Lidar sensor -->
     <xacro:os_device name="os1_sensor" parent="rooster_mount" simulation="${simulation}">
-      <origin xyz="0 0 77.258e-3" rpy="0 0 ${-pi/4}" />
+      <origin xyz="0 0 77.258e-3" rpy="0 0 ${ouster_rotation}" />
     </xacro:os_device>
     <!-- add RealSense D435i (the mesh is actually the non-IMU version -->
     <xacro:sensor_d435i name="camera" parent="realsense_parent" use_nominal_extrinsics="${simulation}">

--- a/urdf/rooster_standalone.urdf.xacro
+++ b/urdf/rooster_standalone.urdf.xacro
@@ -18,8 +18,9 @@
   <xacro:include filename="$(find rooster_description)/urdf/rooster.urdf.xacro" />
   <xacro:arg name="simulation" default="false" />
   <xacro:arg name="ground_camera" default="false" />
+  <xacro:arg name="ouster_rotation" default="${-pi/4}" />
   <link name="base"/>
-  <xacro:rooster_device parent="base" simulation="$(arg simulation)" ground_camera="$(arg ground_camera)">
+  <xacro:rooster_device parent="base" simulation="$(arg simulation)" ground_camera="$(arg ground_camera)" ouster_rotation="$(arg ouster_rotation)">
     <!-- this transform makes the robot base coincident with the front camera link -->
     <origin xyz="-0.08425 -0.025 -0.06325" rpy="0 0 0" />
   </xacro:rooster_device>

--- a/urdf/rooster_standalone.urdf.xacro
+++ b/urdf/rooster_standalone.urdf.xacro
@@ -18,7 +18,8 @@
   <xacro:include filename="$(find rooster_description)/urdf/rooster.urdf.xacro" />
   <xacro:arg name="simulation" default="false" />
   <xacro:arg name="ground_camera" default="false" />
-  <xacro:arg name="ouster_rotation" default="${-pi/4}" />
+  <!-- Need to put the arithmetic computation into quotes because otherwise xacro fails to build -->
+  <xacro:arg name="ouster_rotation" default="'${-pi/4}'" />
   <link name="base"/>
   <xacro:rooster_device parent="base" simulation="$(arg simulation)" ground_camera="$(arg ground_camera)" ouster_rotation="$(arg ouster_rotation)">
     <!-- this transform makes the robot base coincident with the front camera link -->


### PR DESCRIPTION
Previously the rotation of the ouster on the rooster model has been fixed at -pi/4, but some of the newer roosters will have the cable facing directly backwards. This modification allows specification of the rotation of the ouster with the `ouster_rotation` parameter when importing the xacro, for example

```
  <xacro:rooster_device parent="mount_point" ouster_rotation="0">
```